### PR TITLE
refactor: move inline styles to external CSS file

### DIFF
--- a/resources/css/404.css
+++ b/resources/css/404.css
@@ -1,0 +1,81 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    background: #F8F9FA;
+    user-select: none;
+    overflow: hidden;
+}
+
+
+img {
+    width: 746px;
+    height: 595px;
+    left: 760px;
+    top: 174px;
+    position: relative;
+    user-select: none;
+}
+
+.home {
+    left: 166px;
+    top: 600px;
+    position: absolute;
+    text-align: center;
+    color: white;
+    font-size: 20px;
+    font-family: Outfit;
+    font-weight: 500;
+    word-wrap: break-word;
+    text-decoration: none;
+    user-select: none;
+}
+
+.not-found {
+    left: 137px;
+    top: 196px;
+    position: absolute;
+    color: #40548B;
+    font-size: 156px;
+    font-family: Outfit;
+    font-weight: 400;
+    word-wrap: break-word;
+    user-select: none;
+}
+
+.page-not-found {
+    left: 137px;
+    top: 368px;
+    position: absolute;
+    color: #40548B;
+    font-size: 40px;
+    font-family: Outfit;
+    font-weight: 400;
+    word-wrap: break-word;
+    user-select: none;
+}
+
+.removed {
+    width: 409px;
+    left: 137px;
+    top: 469px;
+    position: absolute;
+    color: #40548B;
+    font-size: 24px;
+    font-family: Outfit;
+    font-weight: 400;
+    word-wrap: break-word;
+    user-select: none;
+}
+
+.button {
+    width: 182px;
+    height: 65px;
+    left: 137px;
+    top: 580px;
+    position: absolute;
+    background: #2D7F6A;
+    border-radius: 100px;
+    user-select: none;
+}

--- a/resources/views/components/404.html
+++ b/resources/views/components/404.html
@@ -5,98 +5,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found</title>
-    <style>
-        html, body {
-            width: 100%;
-            height: 100%;
-            margin: 0;
-            padding: 0;
-            background: #F8F9FA;
-            user-select: none;
-            overflow: hidden;
-        }
-
-
-        img {
-            width: 746px;
-            height: 595px;
-            left: 760px;
-            top: 174px;
-            position: relative;
-            user-select: none;
-        }
-
-        .home {
-            left: 166px;
-            top: 600px;
-            position: absolute;
-            text-align: center;
-            color: white;
-            font-size: 20px;
-            font-family: Outfit;
-            font-weight: 500;
-            word-wrap: break-word;
-            text-decoration: none;
-            user-select: none;
-        }
-
-        .not-found {
-            left: 137px;
-            top: 196px;
-            position: absolute;
-            color: #40548B;
-            font-size: 156px;
-            font-family: Outfit;
-            font-weight: 400;
-            word-wrap: break-word;
-            user-select: none;
-        }
-
-        .page-not-found {
-            left: 137px;
-            top: 368px;
-            position: absolute;
-            color: #40548B;
-            font-size: 40px;
-            font-family: Outfit;
-            font-weight: 400;
-            word-wrap: break-word;
-            user-select: none;
-        }
-
-        .removed {
-            width: 409px;
-            left: 137px;
-            top: 469px;
-            position: absolute;
-            color: #40548B;
-            font-size: 24px;
-            font-family: Outfit;
-            font-weight: 400;
-            word-wrap: break-word;
-            user-select: none;
-        }
-
-        .button {
-            width: 182px;
-            height: 65px;
-            left: 137px;
-            top: 580px;
-            position: absolute;
-            background: #2D7F6A;
-            border-radius: 100px;
-            user-select: none;
-        }
-    </style>
+    <link rel="stylesheet" href="/resources/css/404.css">
 </head>
 
 <body>
     <div class="not-found">404</div>
-    <img src="../../../public/404_img.png" />
+    <img src="/404_img.png" alt="404 Image"/>
     <div class="page-not-found">Page Not found</div>
     <div class="removed">Sorry, the page you're looking for doesn't exist or has been removed.</div>
-    <a href="#" class="button"></a>
-    <a href="#" class="home">Back to Home</a>
+    <a href="/home" class="button" onclick="resetSelectable()"></a>
+    <a href="/home" class="home" onclick="resetSelectable()">Back to Home</a>
+
+    <script>
+        function resetSelectable() {
+            localStorage.removeItem('lastClickedLink');
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
This pull request focuses on improving the maintainability and structure of the 404 error page by separating the CSS into its file and adding a small JavaScript function. The most important changes include moving inline styles to a dedicated CSS file, updating the HTML to reference the new stylesheet, and adding functionality to the "Back to Home" button.

### Separation of CSS:

* [`resources/css/404.css`](diffhunk://#diff-35ddef3062e25a86eef914d21998b8e52b2d4ce441c6d092503a9d5e6f2a77e0R1-R81): Added a new CSS file containing all the styles previously defined inline in the HTML file.
* [`resources/views/components/404.html`](diffhunk://#diff-a1d6d581ca35da7eef965e2db95f4c1c55683153e7107575936e50b9d2d25a2dL8-R23): Removed inline styles and added a link to the new CSS file.

### HTML and JavaScript updates:

* [`resources/views/components/404.html`](diffhunk://#diff-a1d6d581ca35da7eef965e2db95f4c1c55683153e7107575936e50b9d2d25a2dL8-R23): Updated the "Back to Home" button to include an `onclick` event that calls a new JavaScript function to reset a local storage item.
* [`resources/views/components/404.html`](diffhunk://#diff-a1d6d581ca35da7eef965e2db95f4c1c55683153e7107575936e50b9d2d25a2dL8-R23): Modified the image source path and added an alt attribute for better accessibility.