### PR TITLE
refactor: change the include url

### DIFF
--- a/app/ErrorHandler.php
+++ b/app/ErrorHandler.php
@@ -5,6 +5,6 @@ class ErrorHandler
     public static function handle404()
     {
         http_response_code(404);
-        include '../../resources/views/components/404.html';
+        include '../resources/views/components/404.html';
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `ErrorHandler` class in the `app/ErrorHandler.php` file. The change updates the path to the 404 error page to correct the directory structure.

* [`app/ErrorHandler.php`](diffhunk://#diff-8a77005fdf8316fc61692f94a995f7197750df00020e8fab0874197662c1382dL8-R8): Updated the path to the 404 error page from `'../../resources/views/components/404.html'` to `'../resources/views/components/404.html'`.