### PR TITLE
feat: update README.md to specify Laragon and Nginx as web server requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A web-based system for managing and tracking student achievements using PHP Slim
 - PHP 8.0 or higher
 - Composer
 - SQL Server
-- Web server (Apache/Nginx)
+- Laragon
+- Web server Nginx
 
 ## Installation
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the requirements for the web-based system to specify the use of Laragon and Nginx as the web server.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R11): Updated the requirements to specify Laragon and Nginx instead of Apache/Nginx.