### PR TITLE
fix: change history push to replace for better navigation handling

### DIFF
--- a/resources/js/load-page.js
+++ b/resources/js/load-page.js
@@ -10,7 +10,7 @@ window.loadPage = async function (page) {
         }
         const html = await response.text();
         document.querySelector('#content').innerHTML = html;
-        window.history.pushState({ page }, '', `/dashboard`);
+        window.history.replaceState({ page }, '', `/dashboard`);
     } catch (error) {
         console.error('Error loading page:', error);
         document.querySelector('#content').innerHTML = `<h1>Error: ${error.message}</h1>`;


### PR DESCRIPTION
This pull request includes a change to the `loadPage` function in `resources/js/load-page.js` to improve the way the browser history is managed when loading new pages.

* [`resources/js/load-page.js`](diffhunk://#diff-1fcd3c2e2a890b4a477ad5ef839b6b75fd6fd37fa4c6884b71e0350315da9046L13-R13): Changed `window.history.pushState` to `window.history.replaceState` to prevent adding new entries to the browser history for each page load.