### PR TITLE
feat: enhance navigation by saving and loading the last visited page in local storage

### DIFF
--- a/resources/views/components/navbar.html
+++ b/resources/views/components/navbar.html
@@ -14,7 +14,7 @@
     </div>
     <div class="two-icon">
         <img src="/assets/icons/notification.png" alt="" class="notification">
-        <a href="/logout">
+        <a href="/logout" onclick="localStorage.clear()">
             <img src="/assets/icons/log-out.png" alt="" class="log-out">
         </a>
     </div>

--- a/resources/views/dashboard.php
+++ b/resources/views/dashboard.php
@@ -18,10 +18,20 @@
     <script>
         const loadPage = window.loadPage;
 
+        window.addEventListener('load', () => {
+            const lastPage = localStorage.getItem('currentPage') || 'home';
+
+            const navLink = document.querySelector(`.navlink .link[href="${lastPage}"]`);
+            if (navLink) {
+                navLink.click();
+            }
+        });
+
         document.querySelectorAll('.navlink .link').forEach(link => {
             link.addEventListener('click', async function(e) {
                 e.preventDefault();
                 const page = this.getAttribute('href');
+                localStorage.setItem('currentPage', page);
                 await window.loadPage(page);
             });
         });
@@ -30,12 +40,14 @@
             if (event.state && event.state.page) {
                 window.loadPage(event.state.page);
             } else {
-                window.loadPage('home');
+                const lastPage = localStorage.getItem('currentPage') || 'home';
+                window.loadPage(lastpage);
             }
         }
 
-        // Load initial content based on URL or default to 'home'
-        window.loadPage('home');
+        // Load last visited page or default to home
+        const initialPage = localStorage.getItem('currentPage') || 'home';
+        window.loadPage(initialPage);
     </script>
 </body>
 


### PR DESCRIPTION
This pull request includes changes to improve user experience by remembering the last visited page and clearing local storage on logout. The most important changes include adding functionality to store the current page in local storage and updating the logout link to clear local storage.

User experience improvements:

* [`resources/views/dashboard.php`](diffhunk://#diff-242f62d0fe60369da8f6c1e8a35a4a9769f930191ad4c0897261b5281ef7a722R21-R34): Added event listener to store the current page in local storage and load the last visited page on window load. [[1]](diffhunk://#diff-242f62d0fe60369da8f6c1e8a35a4a9769f930191ad4c0897261b5281ef7a722R21-R34) [[2]](diffhunk://#diff-242f62d0fe60369da8f6c1e8a35a4a9769f930191ad4c0897261b5281ef7a722L33-R50)
* [`resources/views/components/navbar.html`](diffhunk://#diff-4979d9b3a9a5df36bfb122239440fadded9ae5eaae9274f516ee5e8ac247415dL17-R17): Updated the logout link to clear local storage when clicked.