### PR TITLE
feat: Add ranking display for students in home view and update DashboardController to retrieve ranks

### DIFF
--- a/app/Controller/DashboardController.php
+++ b/app/Controller/DashboardController.php
@@ -37,7 +37,8 @@ class DashboardController extends Controller
                 if ($page === 'home') {
                     $data = [
                         'stats' => $this->achievementModel->getAchievementStats(),
-                        'adminRecent' => $this->achievementModel->getRecentAchievements()
+                        'adminRecent' => $this->achievementModel->getRecentAchievements(),
+                        'rankAdmin' => $this->studentModel->getRank(6),
                     ];
                 } elseif ($page === 'user') {
                     $data = [

--- a/resources/views/pages/home.php
+++ b/resources/views/pages/home.php
@@ -39,37 +39,28 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <td>1</td>
-                                <td>Alexandra Grace</td>
-                                <td>7</td>
-                            </tr>
-                            <tr>
-                                <td>2</td>
-                                <td>Nathaniel James</td>
-                                <td>6</td>
-                            </tr>
-                            <tr>
-                                <td>3</td>
-                                <td>Nathaniel James</td>
-                                <td>6</td>
-                            </tr>
-                            <td>4</td>
-                            <td>Anindya</td>
-                            <td>6</td>
-                            </tr>
-                            <td>5</td>
-                            <td>Nathaniel James</td>
-                            <td>6</td>
-                            </tr>
-                            <td>6</td>
-                            <td>Nathaniel James</td>
-                            <td>1</td>
-                            </tr>
-                            <td></td>
-                            <td>See all</td>
-                            <td></td>
-                            </tr>
+                            <?php if (isset($rankAdmin) && is_array($rankAdmin) && !empty($rankAdmin)) : ?>
+                                <?php foreach ($rankAdmin as $rank) : ?>
+                                    <?php if (isset($rank['total_achievements']) && $rank['total_achievements'] > 0) : ?>
+                                        <tr>
+                                            <td><?php echo $rank['rank']; ?></td>
+                                            <td><?php echo htmlspecialchars($rank['student_name']); ?></td>
+                                            <td><?php echo $rank['total_achievements']; ?></td>
+                                        </tr>
+                                    <?php endif; ?>
+                                <?php endforeach; ?>
+                                <?php if (count($rankAdmin) > 6): ?>
+                                    <tr>
+                                        <td></td>
+                                        <td>See all</td>
+                                        <td></td>
+                                    </tr>
+                                <?php endif; ?>
+                            <?php else : ?>
+                                <tr>
+                                    <td colspan="3" class="text-center">No data available</td>
+                                </tr>
+                            <?php endif; ?>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
This pull request includes changes to the `DashboardController` and the home page view to display the rank of administrators based on their achievements.

### Improvements to the Dashboard:

* [`app/Controller/DashboardController.php`](diffhunk://#diff-224b7ff7ff0a4cc61ac949c8b8c17a962ee60fb9e1b0243aa0896403e6773c06L40-R41): Added a new data element `rankAdmin` to the home page data array, which retrieves the rank of administrators from the `studentModel`.

### Enhancements to the Home Page View:

* [`resources/views/pages/home.php`](diffhunk://#diff-5c8bf55160d8edad76c61b84852b2921cbfa504e1634936d648988dc8bf01d2bR42-R63): Updated the table to display the rank, name, and total achievements of administrators dynamically. Added checks to handle cases where the `rankAdmin` data is empty or not set, and included a "See all" row if there are more than six administrators.